### PR TITLE
fix: make the Ask about Pablo bar fully clickable, outline icons again

### DIFF
--- a/src/components/Chat/Chat.styles.ts
+++ b/src/components/Chat/Chat.styles.ts
@@ -5,52 +5,12 @@ import mediaQueries from '../../styles/mediaQueries.styles';
 const PANEL_WIDTH = '38rem';
 const PANEL_HEIGHT = '58rem';
 
+/* Barra colapsada: pastilla de tamaño fijo. El radio iguala la altura
+   para que los extremos queden completamente redondeados. */
+const BAR_WIDTH = '26rem';
+const BAR_HEIGHT = '5rem';
+
 const OPEN_TRANSITION = '.2s ease-in-out';
-
-export const Panel = styled.div<{ $open: boolean }>`
-    ${({ theme, $open }) => css`
-        /* El panel es siempre la misma caja: cerrado, se ve solo la
-           cabecera; al abrir, crece hacia arriba/lados sin moverse de
-           sitio, así el chat se despliega bajo el propio botón. Móvil
-           primero: pantalla completa al abrir — ver riesgo #5 del plan,
-           una burbuja flotante taparía el contenido en pantallas
-           pequeñas. */
-        background: ${theme.colorBg};
-        border: 0;
-        border-radius: ${$open ? 0 : theme.r200};
-        bottom: ${$open ? 0 : theme.r200};
-        box-shadow: ${theme.boxShadowBottom4};
-        display: flex;
-        flex-direction: column;
-        height: ${$open ? '100dvh' : theme.iconDefaultSize};
-        overflow: hidden;
-        position: fixed;
-        right: ${$open ? 0 : theme.r200};
-        transition: ${OPEN_TRANSITION};
-        transition-property: border-radius, bottom, height, right, width;
-        width: ${$open ? '100vw' : `min(${PANEL_WIDTH}, calc(100vw - ${theme.r400}))`};
-        z-index: ${theme.zModal};
-
-        @media ${mediaQueries.tablet} {
-            border: ${theme.borderM} solid ${theme.neutral900};
-            border-radius: ${theme.r200};
-            bottom: ${theme.r300};
-            height: ${$open ? `min(${PANEL_HEIGHT}, 75vh)` : theme.iconDefaultSize};
-            right: ${theme.r300};
-            width: min(${PANEL_WIDTH}, calc(100vw - ${theme.r400}));
-        }
-    `};
-`;
-
-export const Body = styled.div`
-    ${css`
-        display: flex;
-        flex: 1;
-        flex-direction: column;
-        min-height: 0;
-        overflow: hidden;
-    `};
-`;
 
 /* Toda la barra es el botón que abre/cierra el chat: un <p> y un
    icono sueltos solo eran clicables en su propia caja, dejando el
@@ -66,7 +26,10 @@ export const Header = styled.button`
         flex: none;
         font: inherit;
         justify-content: space-between;
-        padding: ${theme.r150} ${theme.r200};
+        /* Sin padding vertical: la altura la fija min-height y el
+           contenido se centra solo, sin depender del interlineado. */
+        min-height: ${BAR_HEIGHT};
+        padding: 0 ${theme.r200};
         text-align: left;
         width: 100%;
 
@@ -74,6 +37,61 @@ export const Header = styled.button`
             outline: ${theme.borderS} solid ${theme.neutral050};
             outline-offset: -${theme.borderM};
         }
+    `};
+`;
+
+export const Panel = styled.div<{ $open: boolean }>`
+    ${({ theme, $open }) => css`
+        /* El panel es siempre la misma caja: cerrado, se ve solo la
+           cabecera; al abrir, crece hacia arriba/lados sin moverse de
+           sitio, así el chat se despliega bajo el propio botón. Móvil
+           primero: pantalla completa al abrir — ver riesgo #5 del plan,
+           una burbuja flotante taparía el contenido en pantallas
+           pequeñas. */
+        background: ${theme.colorBg};
+        border: 0;
+        border-radius: ${$open ? 0 : BAR_HEIGHT};
+        bottom: ${$open ? 0 : theme.r200};
+        box-shadow: ${theme.boxShadowBottom4};
+        display: flex;
+        flex-direction: column;
+        height: ${$open ? '100dvh' : BAR_HEIGHT};
+        overflow: hidden;
+        position: fixed;
+        right: ${$open ? 0 : theme.r200};
+        transition: ${OPEN_TRANSITION};
+        transition-property: border-radius, bottom, height, right, width;
+        width: ${$open ? '100vw' : `min(${BAR_WIDTH}, calc(100vw - ${theme.r400}))`};
+        z-index: ${theme.zModal};
+
+        ${!$open &&
+        css`
+            /* Colapsado la cabecera es lo único visible: que ocupe todo
+               el alto real de la pastilla — descontando el borde, que
+               resta al box interior — y no deje ver el fondo del panel. */
+            ${Header} {
+                min-height: 100%;
+            }
+        `};
+
+        @media ${mediaQueries.tablet} {
+            border: ${theme.borderM} solid ${theme.neutral900};
+            border-radius: ${$open ? theme.r200 : BAR_HEIGHT};
+            bottom: ${theme.r300};
+            height: ${$open ? `min(${PANEL_HEIGHT}, 75vh)` : BAR_HEIGHT};
+            right: ${theme.r300};
+            width: ${$open ? `min(${PANEL_WIDTH}, calc(100vw - ${theme.r400}))` : BAR_WIDTH};
+        }
+    `};
+`;
+
+export const Body = styled.div`
+    ${css`
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        min-height: 0;
+        overflow: hidden;
     `};
 `;
 

--- a/src/components/Chat/Chat.styles.ts
+++ b/src/components/Chat/Chat.styles.ts
@@ -52,19 +52,34 @@ export const Body = styled.div`
     `};
 `;
 
-export const Header = styled.header`
+/* Toda la barra es el botón que abre/cierra el chat: un <p> y un
+   icono sueltos solo eran clicables en su propia caja, dejando el
+   resto de la franja muerta al tacto/clic. */
+export const Header = styled.button`
     ${({ theme }) => css`
         align-items: center;
         background: ${theme.neutral700};
+        border: none;
         color: ${theme.neutral050};
+        cursor: pointer;
         display: flex;
         flex: none;
+        font: inherit;
         justify-content: space-between;
         padding: ${theme.r150} ${theme.r200};
+        text-align: left;
+        width: 100%;
+
+        &:focus-visible {
+            outline: ${theme.borderS} solid ${theme.neutral050};
+            outline-offset: -${theme.borderM};
+        }
     `};
 `;
 
-export const Title = styled.p`
+// span, no p: vive dentro de un <button> y <p> no es contenido de fraseo
+// (el modelo de contenido de <button> solo admite ese tipo de hijos).
+export const Title = styled.span`
     ${({ theme }) => css`
         font-size: ${theme.b1};
         font-weight: ${theme.bold};
@@ -74,23 +89,16 @@ export const Title = styled.p`
     `};
 `;
 
-export const ToggleButton = styled.button`
+export const ToggleIcon = styled.span`
     ${({ theme }) => css`
-        background: none;
-        border: none;
-        color: inherit;
-        cursor: pointer;
+        align-items: center;
         display: flex;
         flex: none;
-        padding: ${theme.r025};
+        justify-content: center;
 
         svg {
             height: ${theme.iconsSizeS};
             width: ${theme.iconsSizeS};
-        }
-
-        &:focus-visible {
-            outline: ${theme.borderS} solid ${theme.neutral050};
         }
     `};
 `;

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -20,7 +20,7 @@ import {
     SuggestionList,
     TextArea,
     Title,
-    ToggleButton,
+    ToggleIcon,
     TypingIndicator,
 } from './Chat.styles';
 
@@ -112,11 +112,9 @@ export default function Chat() {
 
     return (
         <Panel $open={isOpen} role="region" aria-label="Chat about Pablo Grillo">
-            <Header>
+            <Header type="button" onClick={handleToggle} aria-label={isOpen ? 'Close' : 'Ask about Pablo'} aria-expanded={isOpen}>
                 <Title>Ask about Pablo</Title>
-                <ToggleButton type="button" onClick={handleToggle} aria-label={isOpen ? 'Close' : 'Ask about Pablo'}>
-                    {isOpen ? <Icons.Close /> : <Icons.MessageCircle />}
-                </ToggleButton>
+                <ToggleIcon aria-hidden="true">{isOpen ? <Icons.Close /> : <Icons.MessageCircle />}</ToggleIcon>
             </Header>
 
             {hasOpened && (

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -41,9 +41,22 @@ const Github = styled(GithubIcon)`
 
 // Sin defaultIconProps: estos no son iconos de lista con texto al lado,
 // se dimensionan y colorean en el punto de uso (ver Chat.styles.ts).
-const MessageCircle = styled(MessageCircleIcon)``;
-const Close = styled(XIcon)``;
-const Send = styled(SendIcon)``;
+// Son iconos de trazo (Feather): pisan el "fill: currentColor" global,
+// que los rellenaría en vez de dejarlos solo con el borde.
+const strokeIconProps = css`
+    fill: none;
+    stroke: currentColor;
+`;
+
+const MessageCircle = styled(MessageCircleIcon)`
+    ${strokeIconProps}
+`;
+const Close = styled(XIcon)`
+    ${strokeIconProps}
+`;
+const Send = styled(SendIcon)`
+    ${strokeIconProps}
+`;
 
 const WrapperDown = styled.div`
     ${({ theme, visible }) => css`


### PR DESCRIPTION
## Summary
- The global `svg { fill: currentColor }` rule (meant for the solid contact icons) was overriding the Feather icons' own `fill="none"`, so `message-circle`, `close` and `send` rendered as solid blobs instead of outlined strokes. Scoped `fill: none; stroke: currentColor;` back onto those three icons.
- Only the small icon inside the "Ask about Pablo" header bar opened/closed the chat; the title text next to it was dead click space. The whole bar is now a single `<button>`, so clicking anywhere on it toggles the chat, while keeping the same centered flex layout.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] Verified visually with Playwright: icons render as outlines (not filled), clicking the title text (not just the icon) opens/closes the chat, layout stays centered on desktop and mobile.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LS9KrT9GF2W4zJKH7R2EwU)_