### PR TITLE
feat: highlight the content a chat answer points at

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import type { FormEvent, KeyboardEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { FormEvent, KeyboardEvent, MouseEvent } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { isTextUIPart, type UIMessage } from 'ai';
 import ReactMarkdown from 'react-markdown';
 
 import * as Icons from '../../icons';
+import { highlightTarget } from '../../lib/highlight';
+import mediaQueries from '../../styles/mediaQueries.styles';
 import {
     Body,
     EmptyState,
@@ -37,14 +39,23 @@ function messageText(message: UIMessage): string {
     return message.parts.filter(isTextUIPart).map((part) => part.text).join('');
 }
 
-const markdownComponents = {
+/** Componentes de react-markdown, parametrizados con el manejador de anclas. */
+const buildMarkdownComponents = (onAnchorClick: (event: MouseEvent<HTMLAnchorElement>) => void) => ({
     p: ({ children }: { children?: React.ReactNode }) => <p>{children}</p>,
-    a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
-        <a href={href} target={href?.startsWith('#') ? undefined : '_blank'} rel="noreferrer">
-            {children}
-        </a>
-    ),
-};
+    a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
+        const isAnchor = href?.startsWith('#') ?? false;
+        return (
+            <a
+                href={href}
+                target={isAnchor ? undefined : '_blank'}
+                rel="noreferrer"
+                onClick={isAnchor ? onAnchorClick : undefined}
+            >
+                {children}
+            </a>
+        );
+    },
+});
 
 export default function Chat() {
     const [isOpen, setIsOpen] = useState(false);
@@ -142,6 +153,25 @@ export default function Chat() {
             void sendMessage({ text: trimmed });
         },
         [isBusy, sendMessage],
+    );
+
+    // Un enlace a un ancla no navega: llevamos nosotros la vista hasta el
+    // contenido y lo resaltamos. En móvil el panel ocupa toda la pantalla,
+    // así que además hay que cerrarlo o el visitante no vería el destino.
+    const handleAnchorClick = useCallback((event: MouseEvent<HTMLAnchorElement>) => {
+        const href = event.currentTarget.getAttribute('href');
+        if (!href?.startsWith('#')) return;
+
+        const floatingPanel = window.matchMedia(mediaQueries.tablet).matches;
+        if (!highlightTarget(decodeURIComponent(href.slice(1)))) return;
+
+        event.preventDefault();
+        if (!floatingPanel) setIsOpen(false);
+    }, []);
+
+    const markdownComponents = useMemo(
+        () => buildMarkdownComponents(handleAnchorClick),
+        [handleAnchorClick],
     );
 
     const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {

--- a/src/content/cv.ts
+++ b/src/content/cv.ts
@@ -46,6 +46,8 @@ export interface SkillsSection {
 }
 
 export interface WorkItem {
+    /** Ancla de la entrada, derivada — ver `withAnchors`. */
+    id: string;
     year: number;
     company: string;
     role: string;
@@ -60,6 +62,8 @@ export interface WorkSection {
 }
 
 export interface EducationItem {
+    /** Ancla de la entrada, derivada — ver `withAnchors`. */
+    id: string;
     year: number;
     title: string;
     school: string;
@@ -74,6 +78,8 @@ export interface EducationSection {
 }
 
 export interface CourseItem {
+    /** Ancla de la entrada, derivada — ver `withAnchors`. */
+    id: string;
     year: number;
     title: string;
     org: string;
@@ -105,6 +111,46 @@ export interface ContactSection {
 }
 
 export type Section = AboutSection | SkillsSection | WorkSection | EducationSection | CoursesSection | ContactSection;
+
+/**
+ * Convierte un texto en un fragmento de ancla: sin acentos, en minúsculas
+ * y separado por guiones. Se corta a cuatro palabras porque estas anclas
+ * las escribe el modelo del chat en sus respuestas, y una cadena corta es
+ * más difícil de equivocar (y más barata en tokens) que un título entero.
+ */
+const slug = (value: string): string => value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .split('-')
+    .slice(0, 4)
+    .join('-');
+
+/**
+ * Deriva el `id` de cada entrada a partir de su propio contenido, en vez de
+ * escribirlo a mano, para que no pueda desincronizarse de lo que se ve en
+ * pantalla. El año va al final porque desempata las entradas que comparten
+ * empresa o título (Roiback aparece dos veces). Estos ids son a la vez el
+ * ancla del HTML y la que el chat cita en sus respuestas, así que
+ * cambiarlos rompe enlaces ya compartidos: trátalos como parte del
+ * contenido, no como un detalle interno.
+ */
+const withAnchors = <T extends { year: number }>(
+    prefix: string,
+    key: (item: T) => string,
+    items: T[],
+): (T & { id: string })[] => {
+    const ids = items.map((item) => `${prefix}-${slug(key(item))}-${item.year}`);
+    const duplicate = ids.find((id, index) => ids.indexOf(id) !== index);
+
+    if (duplicate) {
+        throw new Error(`cv.ts: dos entradas de "${prefix}" comparten el ancla "${duplicate}".`);
+    }
+
+    return items.map((item, index) => ({ ...item, id: ids[index] }));
+};
 
 export const profile: Profile = {
     name: 'pablo grillo',
@@ -203,7 +249,7 @@ export const work: WorkSection = {
     id: 'work',
     label: 'Work',
     columnSplit: 4,
-    items: [
+    items: withAnchors('work', (item) => item.company, [
         {
             year: 2023,
             company: 'Roiback',
@@ -246,14 +292,14 @@ export const work: WorkSection = {
             role: 'Co-Founder',
             description: 'Audiovisual production and post-production. Motion Graphics.',
         },
-    ],
+    ]),
 };
 
 export const education: EducationSection = {
     id: 'education',
     label: 'Education',
     columnSplit: 2,
-    items: [
+    items: withAnchors('education', (item) => item.title, [
         {
             year: 2012,
             title: 'User Experience Design | Human Computer Interaction',
@@ -276,14 +322,14 @@ export const education: EducationSection = {
             school: 'Universidad de Buenos Aires',
             note: 'two years completed',
         },
-    ],
+    ]),
 };
 
 export const courses: CoursesSection = {
     id: 'courses',
     label: 'Courses',
     columnSplit: 4,
-    items: [
+    items: withAnchors('courses', (item) => item.title, [
         {
             year: 2024,
             title: 'Google Data Analytics Professional Certificate',
@@ -325,7 +371,7 @@ export const courses: CoursesSection = {
             org: 'UBA',
             url: 'https://www.uba.ar/',
         },
-    ],
+    ]),
 };
 
 export const contact: ContactSection = {

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,0 +1,38 @@
+/**
+ * Resaltado del contenido al que apunta un enlace del chat.
+ *
+ * El chat responde citando anclas de la página (`[Roiback](#work-roiback-2023)`).
+ * Al pulsarlas no basta con saltar: el visitante aterriza en mitad de un CV
+ * denso sin saber qué parte le estaban señalando. Marcamos el destino con un
+ * atributo y `global.styles.js` se encarga de teñirlo y desvanecerlo.
+ */
+
+/** Lo lee el selector de global.styles.js — cámbialo en los dos sitios. */
+export const HIGHLIGHT_ATTR = 'data-chat-highlight';
+
+/**
+ * Lleva la vista al elemento y lo resalta. Devuelve `false` si el ancla no
+ * existe, para que quien llame pueda dejar que el navegador haga lo suyo en
+ * vez de tragarse el clic.
+ */
+export function highlightTarget(id: string): boolean {
+    const target = document.getElementById(id);
+    if (!target) return false;
+
+    const stillMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    target.scrollIntoView({ behavior: stillMotion ? 'auto' : 'smooth', block: 'center' });
+
+    // Quitar y volver a poner el atributo reinicia la animación: sin esto,
+    // pulsar dos veces el mismo enlace no resaltaría la segunda vez.
+    target.removeAttribute(HIGHLIGHT_ATTR);
+    void target.offsetWidth;
+    target.setAttribute(HIGHLIGHT_ATTR, '');
+
+    target.addEventListener(
+        'animationend',
+        () => target.removeAttribute(HIGHLIGHT_ATTR),
+        { once: true },
+    );
+
+    return true;
+}

--- a/src/lib/systemPrompt.ts
+++ b/src/lib/systemPrompt.ts
@@ -17,18 +17,18 @@ function serializeCV(): string {
         .join('\n');
 
     const workText = work.items
-        .map((item) => `${item.year} — ${item.company}, ${item.role}\n${item.description}`)
+        .map((item) => `${item.year} — ${item.company}, ${item.role} (#${item.id})\n${item.description}`)
         .join('\n\n');
 
     const educationText = education.items
         .map((item) => {
             const note = item.note ? ` (${item.note})` : '';
-            return `${item.year} — ${item.title}, ${item.school}${note}`;
+            return `${item.year} — ${item.title}, ${item.school}${note} (#${item.id})`;
         })
         .join('\n');
 
     const coursesText = courses.items
-        .map((item) => `${item.year} — ${item.title}, ${item.org}`)
+        .map((item) => `${item.year} — ${item.title}, ${item.org} (#${item.id})`)
         .join('\n');
 
     return [
@@ -64,10 +64,14 @@ Cómo responder:
   mucha gente preguntará en español).
 - Respuestas breves: dos o tres frases salvo que pidan detalle.
 - Habla de ${profile.fullName.split(' ')[0]} en tercera persona. No eres él.
-- Cuando la respuesta viva en una sección de la página, enlázala en
-  Markdown usando el ancla que aparece junto al título de esa sección en
-  <cv> (por ejemplo [Work](#work)). Esto lleva al visitante directamente
-  a esa parte de la página.
+- Cuando la respuesta viva en la página, enlázala en Markdown usando un
+  ancla de <cv>. Al pulsarla, la web lleva al visitante hasta ahí y
+  resalta ese contenido, así que usa siempre la más precisa que exista:
+  la de la entrada concreta si hablas de un puesto, una carrera o un
+  curso (por ejemplo [Roiback](#work-roiback-2023)), y la de la sección
+  solo si hablas de ella en conjunto (por ejemplo [Work](#work)).
+- Copia las anclas tal cual aparecen en <cv>. Si no encuentras la de una
+  entrada, enlaza su sección en lugar de inventarte un ancla.
 
 Límites:
 - Si la respuesta no está en <cv>, dilo con naturalidad y sugiere escribir

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -51,13 +51,16 @@ const Paragraph = ({ segments }) => (
     </Typo.P>
 );
 
+// El <div> agrupa año y contenido en una sola caja — válido dentro de un
+// <dl> — para que el ancla de la entrada tenga algo que señalar y el chat
+// pueda resaltarla entera de una pieza. Ver src/lib/highlight.ts.
 const DefinitionColumn = ({ items, renderItem }) => (
     <dl>
-        {items.map((item, index) => (
-            <Fragment key={`${item.year}-${index}`}>
+        {items.map((item) => (
+            <div key={item.id} id={item.id}>
                 <Typo.YearCss>{item.year}</Typo.YearCss>
                 <dd>{renderItem(item)}</dd>
-            </Fragment>
+            </div>
         ))}
     </dl>
 );

--- a/src/styles/global.styles.js
+++ b/src/styles/global.styles.js
@@ -1,4 +1,21 @@
-import { createGlobalStyle, css } from 'styled-components';
+import { createGlobalStyle, css, keyframes } from 'styled-components';
+
+import { HIGHLIGHT_ATTR } from '../lib/highlight';
+
+/*
+ * El color se mantiene la primera mitad para dar tiempo a que termine el
+ * scroll suave — si empezara a apagarse ya, el destino llegaría descolorido.
+ */
+const highlightFade = (theme) => keyframes`
+    0%, 50% {
+        background-color: ${theme.main050};
+        outline-color: ${theme.main500};
+    }
+    100% {
+        background-color: transparent;
+        outline-color: transparent;
+    }
+`;
 
 const GlobalStyle = createGlobalStyle`
     ${({ theme }) => css`
@@ -111,6 +128,18 @@ const GlobalStyle = createGlobalStyle`
         }
         mark {
             background-color: ${theme.main050};
+        }
+
+        /*
+         * Destino de un enlace del chat. Lo pone y lo quita highlight.ts;
+         * aquí solo vive el aspecto. El outline (y no un border) porque no
+         * ocupa espacio y por tanto no descoloca nada al aparecer.
+         */
+        [${HIGHLIGHT_ATTR}] {
+            animation: ${highlightFade(theme)} 2.4s ease-out;
+            border-radius: ${theme.r050};
+            outline: ${theme.borderM} solid transparent;
+            outline-offset: ${theme.r050};
         }
     `};
 `;


### PR DESCRIPTION
## Problem

The chat already cited sections (`[Work](#work)`), but that dropped the visitor into a dense CV with no clue which of eight jobs the answer actually meant. Ask about Roiback and you landed on the whole Work section.

## Changes

**Per-entry anchors.** Every work, education and course entry now has its own `id`, derived from its own content in `cv.ts` rather than hand-written, so it can't drift from what's on screen. The year is the tiebreaker — Roiback appears twice, giving `work-roiback-2023` and `work-roiback-2016`. `withAnchors` throws at module load if two entries ever collide, so a duplicate can't ship silently. Slugs are capped at four words: the model has to reproduce these strings, and a short one is harder to get wrong.

**Markup.** Each entry's `<dt>`/`<dd>` pair is wrapped in a `<div id>` — valid inside a `<dl>` — so the anchor has a single box to point at and the highlight covers the whole entry in one piece.

**Prompt.** Anchors are serialized next to each entry, and the instruction now asks for the most specific anchor available, falling back to the section rather than inventing one.

**Behaviour.** The chat intercepts anchor clicks: it scrolls the target into view (honouring `prefers-reduced-motion`) and sets `data-chat-highlight`; CSS tints it with `main050` plus a `main500` outline and fades it out. The attribute is removed on `animationend` so the same link can be clicked repeatedly. On mobile the panel closes first — full-screen, it would otherwise cover the very thing it just pointed at; on tablet and up it floats, so it stays open. If an anchor doesn't resolve, the click isn't swallowed and the browser handles it.

## Test plan

- [x] `npx tsc --noEmit`, `npm run lint`
- [x] 18 anchors generated, no duplicates, longest 54 chars; `work-roiback-2023` and `work-roiback-2016` correctly distinguished
- [x] End-to-end in Chromium with a stubbed `/api/chat` streaming `Pablo lidera el equipo en [Roiback](#work-roiback-2023) desde 2023.`:

  | | link href | highlighted | scrolled into view | panel |
  |---|---|---|---|---|
  | desktop 1280×900 | `#work-roiback-2023` | yes | yes | stays open |
  | mobile 390×844 | `#work-roiback-2023` | yes | yes | closes |

  Attribute removed after the animation in both cases, so the link re-triggers.
- [x] Only the 2023 entry is tinted — the 2016 Roiback entry directly below is untouched
- [x] Section-level fallback still works: `#work` highlights the whole section
- [x] No layout shift from the wrapper `div`: gaps between Work entries stay at 10px, matching the previous `dd` margin collapsing

Verified against a stubbed model response, so the one thing left to confirm on the preview is that the real model picks the per-entry anchors over the section ones.