### PR TITLE
ci: add a functional test stage on pull requests and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    # develop y master no existen todavía en este repo (la rama larga es
+    # main); van listadas para que el pipeline las cubra si se crean.
+    branches: [main, develop, master]
+
+# Una PR que recibe varios push seguidos solo necesita terminar el último.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint and types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+  e2e:
+    name: Functional tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      # Solo Chromium: es el único navegador que usan los proyectos de
+      # playwright.config.ts, y bajar los tres triplicaría el arranque.
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      # Las pruebas suplantan /api/chat (ver tests/support/chat.ts), así que
+      # no hace falta una clave real — pero el módulo del cliente de
+      # Anthropic sí quiere encontrar la variable definida al arrancar.
+      - name: Run Playwright
+        run: npm run test:e2e
+        env:
+          ANTHROPIC_API_KEY: dummy-key-for-tests
+
+      - name: Upload report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ yarn-error.log*
 
 .idea
 .claude
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "zod": "^4.4.3"
             },
             "devDependencies": {
+                "@playwright/test": "^1.62.1",
                 "@svgr/webpack": "^8.1.0",
                 "@types/node": "26.2.0",
                 "@types/react": "19.2.18",
@@ -2856,6 +2857,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.4.0"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+            "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.62.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/@rtsao/scc": {
@@ -5818,6 +5835,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -8084,6 +8116,38 @@
             "license": "MIT",
             "engines": {
                 "node": ">=16.20.0"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+            "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.62.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+            "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
         "dev": "next dev",
         "build": "next build",
         "start": "next start",
-        "lint": "eslint ."
+        "lint": "eslint .",
+        "test:e2e": "playwright test",
+        "test:e2e:ui": "playwright test --ui"
     },
     "dependencies": {
         "@ai-sdk/anthropic": "^4.0.39",
@@ -26,6 +28,7 @@
         "node": "24.x"
     },
     "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@svgr/webpack": "^8.1.0",
         "@types/node": "26.2.0",
         "@types/react": "19.2.18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = Number(process.env.PORT ?? 3000);
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${PORT}`;
+const isCI = Boolean(process.env.CI);
+
+export default defineConfig({
+    testDir: './tests',
+    // Estas pruebas tocan el scroll y el resaltado de la propia página, que
+    // es estado global del navegador: dentro de un fichero van en serie, y
+    // el paralelismo se saca ejecutando ficheros a la vez.
+    fullyParallel: false,
+    forbidOnly: isCI,
+    retries: isCI ? 1 : 0,
+    reporter: isCI ? [['github'], ['html', { open: 'never' }]] : [['list']],
+
+    use: {
+        baseURL,
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+    },
+
+    projects: [
+        { name: 'desktop', use: { ...devices['Desktop Chrome'] } },
+        { name: 'mobile', use: { ...devices['Pixel 7'] } },
+    ],
+
+    /*
+     * Se prueba el build de producción, no `next dev`: es lo que acaba
+     * desplegado, y el dev server tiene su propio comportamiento (overlays
+     * de error, recompilación) que no queremos medir. Si ya hay algo
+     * escuchando en el puerto, lo reutiliza en local en vez de fallar.
+     */
+    webServer: process.env.PLAYWRIGHT_BASE_URL
+        ? undefined
+        : {
+            command: `npm run build && npm run start -- --port ${PORT}`,
+            url: baseURL,
+            reuseExistingServer: !isCI,
+            timeout: 180_000,
+        },
+});

--- a/tests/api-chat.spec.ts
+++ b/tests/api-chat.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+/*
+ * La validación de /api/chat responde antes de llamar a Anthropic, así que
+ * se puede comprobar de verdad — sin clave y sin gastar tokens. El camino
+ * feliz necesita ANTHROPIC_API_KEY y se cubre con el stub del cliente, ver
+ * tests/support/chat.ts.
+ */
+test.describe('/api/chat request validation', () => {
+    test('rejects a body that is not JSON', async ({ request }) => {
+        const response = await request.post('/api/chat', {
+            headers: { 'content-type': 'application/json' },
+            data: 'not json at all',
+        });
+
+        expect(response.status()).toBe(400);
+    });
+
+    for (const [name, payload] of [
+        ['no messages', {}],
+        ['messages is not an array', { messages: 'hola' }],
+        ['no messages to answer', { messages: [] }],
+    ] as const) {
+        test(`rejects ${name}`, async ({ request }) => {
+            const response = await request.post('/api/chat', { data: payload });
+
+            expect(response.status()).toBe(400);
+        });
+    }
+
+    test('rejects a conversation that is too long', async ({ request }) => {
+        // El límite existe para que nadie pueda inflar el coste por petición.
+        const messages = Array.from({ length: 31 }, (_, index) => ({
+            id: String(index),
+            role: 'user',
+            parts: [{ type: 'text', text: 'hola' }],
+        }));
+
+        const response = await request.post('/api/chat', { data: { messages } });
+
+        expect(response.status()).toBe(400);
+    });
+});

--- a/tests/chat-anchors.spec.ts
+++ b/tests/chat-anchors.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+
+import { work } from '../src/content/cv';
+import { HIGHLIGHT_ATTR, openChat, stubChatReply } from './support/chat';
+
+// Dos etapas en la misma empresa: el caso que obliga a que las anclas sean
+// por entrada y no por sección.
+const CURRENT = work.items.find((item) => item.company === 'Roiback' && item.year === 2023)!;
+const EARLIER = work.items.find((item) => item.company === 'Roiback' && item.year === 2016)!;
+
+const ANSWER = `Pablo lidera el equipo en [Roiback](#${CURRENT.id}) desde ${CURRENT.year}.`;
+
+test.describe('following a link from an answer', () => {
+    test.beforeEach(async ({ page }) => {
+        await stubChatReply(page, ANSWER);
+        await page.goto('/');
+        await openChat(page);
+        await page.getByPlaceholder('Ask a question…').fill('experiencia en roiback?');
+        await page.keyboard.press('Enter');
+        await expect(page.getByRole('link', { name: 'Roiback' })).toBeVisible();
+    });
+
+    test('points at the entry, not the whole section', async ({ page }) => {
+        await expect(page.getByRole('link', { name: 'Roiback' }))
+            .toHaveAttribute('href', `#${CURRENT.id}`);
+    });
+
+    test('scrolls the entry into view and highlights only that one', async ({ page }) => {
+        await page.getByRole('link', { name: 'Roiback' }).click();
+
+        const target = page.locator(`#${CURRENT.id}`);
+        await expect(target).toHaveAttribute(HIGHLIGHT_ATTR, '');
+        await expect(target).toBeInViewport();
+
+        // La otra etapa en Roiback queda justo debajo: no debe teñirse.
+        await expect(page.locator(`#${EARLIER.id}`)).not.toHaveAttribute(HIGHLIGHT_ATTR, '');
+    });
+
+    test('clears the highlight so the same link works twice', async ({ page, isMobile }) => {
+        const link = page.getByRole('link', { name: 'Roiback' });
+        const target = page.locator(`#${CURRENT.id}`);
+
+        await link.click();
+        await expect(target).toHaveAttribute(HIGHLIGHT_ATTR, '');
+        // La animación se apaga sola y retira la marca.
+        await expect(target).not.toHaveAttribute(HIGHLIGHT_ATTR, '', { timeout: 10_000 });
+
+        // En móvil seguir el enlace cierra el panel; la conversación sigue
+        // ahí, así que basta con volver a abrirlo para repetir el clic.
+        if (isMobile) await openChat(page);
+
+        await link.click();
+        await expect(target).toHaveAttribute(HIGHLIGHT_ATTR, '');
+    });
+
+    test('gets the panel out of the way only when it covers the page', async ({ page, isMobile }) => {
+        await page.getByRole('link', { name: 'Roiback' }).click();
+
+        if (isMobile) {
+            // A pantalla completa el panel taparía justo lo que acaba de señalar.
+            await expect(page.getByRole('button', { name: 'Ask about Pablo' })).toBeVisible();
+        } else {
+            // Flotando en una esquina puede quedarse abierto para seguir preguntando.
+            await expect(page.getByPlaceholder('Ask a question…')).toBeVisible();
+        }
+    });
+});
+
+test('a section link still highlights the whole section', async ({ page }) => {
+    await stubChatReply(page, 'Lo tienes en [Work](#work).');
+    await page.goto('/');
+    await openChat(page);
+    await page.getByPlaceholder('Ask a question…').fill('donde miro su experiencia?');
+    await page.keyboard.press('Enter');
+
+    await page.getByRole('link', { name: 'Work' }).click();
+
+    await expect(page.locator('#work')).toHaveAttribute(HIGHLIGHT_ATTR, '');
+});

--- a/tests/chat.spec.ts
+++ b/tests/chat.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test';
+
+import { openChat, stubChatReply } from './support/chat';
+
+test.describe('chat panel', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+    });
+
+    test('opens from anywhere on the bar, not just the icon', async ({ page }) => {
+        // La barra entera es el botón: pulsar la etiqueta tiene que valer.
+        await page.getByText('Ask about Pablo', { exact: true }).click();
+
+        await expect(page.getByPlaceholder('Ask a question…')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+    });
+
+    test('closes again from the same bar', async ({ page }) => {
+        await openChat(page);
+        await page.getByRole('button', { name: 'Close' }).click();
+
+        await expect(page.getByRole('button', { name: 'Ask about Pablo' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Close' })).toBeHidden();
+
+        // El panel no se desmonta, se repliega: lo que se comprueba es que
+        // vuelve a medir lo que la pastilla, no que el contenido desaparezca.
+        // Con poll, porque replegarse lleva su animación.
+        const panel = page.getByRole('region', { name: 'Chat about Pablo Grillo' });
+        await expect
+            .poll(async () => (await panel.boundingBox())?.height ?? 0)
+            .toBeLessThan(100);
+    });
+
+    test('closes with Escape', async ({ page }) => {
+        await openChat(page);
+        await page.keyboard.press('Escape');
+
+        await expect(page.getByRole('button', { name: 'Ask about Pablo' })).toBeVisible();
+    });
+
+    test('keeps the input readable on the smallest screens', async ({ page }) => {
+        // Por debajo de 16px Safari en iOS amplía la página al enfocar, y ese
+        // zoom descoloca el panel — ver src/components/Chat/Chat.styles.ts.
+        await openChat(page);
+        const fontSize = await page.getByPlaceholder('Ask a question…')
+            .evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+
+        expect(fontSize).toBeGreaterThanOrEqual(16);
+    });
+
+    test('will not send an empty message', async ({ page }) => {
+        await openChat(page);
+
+        await expect(page.getByRole('button', { name: 'Send' })).toBeDisabled();
+        await page.getByPlaceholder('Ask a question…').fill('  ');
+        await expect(page.getByRole('button', { name: 'Send' })).toBeDisabled();
+    });
+
+    test('answers a typed question', async ({ page }) => {
+        await stubChatReply(page, 'Pablo is a Design Engineer.');
+        await openChat(page);
+
+        await page.getByPlaceholder('Ask a question…').fill('what does he do?');
+        await page.keyboard.press('Enter');
+
+        await expect(page.getByText('what does he do?')).toBeVisible();
+        await expect(page.getByText('Pablo is a Design Engineer.')).toBeVisible();
+        // La caja se vacía al enviar, lista para la siguiente pregunta.
+        await expect(page.getByPlaceholder('Ask a question…')).toHaveValue('');
+    });
+
+    test('answers a suggested question', async ({ page }) => {
+        await stubChatReply(page, 'He works at Roiback.');
+        await openChat(page);
+
+        await page.getByRole('button', { name: 'Where does Pablo work right now?' }).click();
+
+        await expect(page.getByText('He works at Roiback.')).toBeVisible();
+    });
+
+    test('offers a retry when the request fails', async ({ page }) => {
+        await page.route('**/api/chat', (route) => route.fulfill({ status: 500, body: 'boom' }));
+        await openChat(page);
+
+        await page.getByPlaceholder('Ask a question…').fill('hola');
+        await page.keyboard.press('Enter');
+
+        await expect(page.getByRole('alert')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+    });
+});

--- a/tests/page.spec.ts
+++ b/tests/page.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+import { work } from '../src/content/cv';
+
+test.describe('CV page', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+    });
+
+    test('renders the profile and every section', async ({ page }) => {
+        await expect(page).toHaveTitle(/Pablo Grillo/);
+        await expect(page.getByRole('heading', { name: 'pablo grillo', level: 1 })).toBeVisible();
+
+        for (const id of ['about', 'work', 'education', 'courses', 'skills', 'contact']) {
+            await expect(page.locator(`#${id}`)).toBeAttached();
+        }
+    });
+
+    test('gives every work entry a unique anchor', async ({ page }) => {
+        // El chat cita estas anclas en sus respuestas: si una desaparece o se
+        // duplica, sus enlaces dejan de llevar a ninguna parte.
+        const ids = await page.locator('#work dl > div[id]').evaluateAll(
+            (entries) => entries.map((entry) => entry.id),
+        );
+
+        expect(ids).toHaveLength(work.items.length);
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(ids).toEqual(work.items.map((item) => item.id));
+    });
+
+    test('shows the current role', async ({ page }) => {
+        const current = work.items[0];
+        const entry = page.locator(`#${current.id}`);
+
+        await expect(entry).toContainText(current.company);
+        await expect(entry).toContainText(current.role);
+        await expect(entry).toContainText(String(current.year));
+    });
+});

--- a/tests/support/chat.ts
+++ b/tests/support/chat.ts
@@ -1,0 +1,38 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Respuesta falsa de /api/chat.
+ *
+ * Las pruebas funcionales miden la web, no al modelo: llamar a Anthropic de
+ * verdad las haría lentas, no deterministas, dependientes de un secreto que
+ * las PRs desde un fork no tienen, y encima costaría dinero por ejecución.
+ * Servimos el mismo stream que produce `toUIMessageStreamResponse()` para
+ * que el cliente del AI SDK no note la diferencia.
+ */
+export async function stubChatReply(page: Page, answer: string): Promise<void> {
+    const chunks = [
+        { type: 'start' },
+        { type: 'text-start', id: 'stub' },
+        { type: 'text-delta', id: 'stub', delta: answer },
+        { type: 'text-end', id: 'stub' },
+        { type: 'finish' },
+    ];
+
+    await page.route('**/api/chat', (route) => route.fulfill({
+        status: 200,
+        headers: {
+            'content-type': 'text/event-stream',
+            'x-vercel-ai-ui-message-stream': 'v1',
+        },
+        body: `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join('')}data: [DONE]\n\n`,
+    }));
+}
+
+/** Abre el panel pulsando la barra, que es un único botón. */
+export async function openChat(page: Page): Promise<void> {
+    await page.getByRole('button', { name: 'Ask about Pablo' }).click();
+    await page.getByPlaceholder('Ask a question…').waitFor();
+}
+
+/** Atributo que marca el destino resaltado — ver src/lib/highlight.ts. */
+export const HIGHLIGHT_ATTR = 'data-chat-highlight';


### PR DESCRIPTION
## Context

Two things worth flagging up front:

- **There was no pipeline at all** — no `.github/` directory existed. So this isn't a stage added to an existing workflow, it's the first one.
- **`develop` and `master` don't exist** in this repo; the long-lived branch is `main`. They're listed in the `push` trigger anyway so the pipeline covers them the day they're created — GitHub simply won't fire for a branch that isn't there.

## What runs

Two jobs, on every pull request and on pushes to `main` / `develop` / `master`:

- **Lint and types** — `npm run lint` and `tsc --noEmit`.
- **Functional tests** — Playwright against the **production build** (`next build && next start` via `webServer`), not `next dev`, since that's what actually ships. Two projects: Desktop Chrome and Pixel 7, so the mobile-specific behaviour is covered. Only Chromium is downloaded. The HTML report uploads as an artifact on failure.

In-progress runs for the same ref are cancelled when a new push lands.

## What's covered

| Spec | What it protects |
|---|---|
| `page.spec.ts` | Sections render; every work entry has a unique anchor matching `cv.ts` — these are what the chat cites, so a duplicate or missing one silently breaks its links |
| `chat.spec.ts` | Opening from anywhere on the bar (not just the icon), closing, Escape, empty-message guard, answering, the error/retry banner, and the ≥16px input that keeps iOS from zooming |
| `chat-anchors.spec.ts` | A link points at the entry rather than the section; only that entry is highlighted (the other Roiback entry below stays untouched); the highlight clears so the link re-triggers; the panel closes on mobile but stays open on desktop |
| `api-chat.spec.ts` | `/api/chat` rejects malformed bodies and over-long conversations |

## Why the chat API is stubbed

Tests fulfil `/api/chat` with the same SSE stream `toUIMessageStreamResponse()` produces (`tests/support/chat.ts`). Calling Anthropic for real would be slow and non-deterministic, cost money on every run, and need a secret that pull requests from a fork can't read. The validation path in `api-chat.spec.ts` runs against the real route, since it returns before reaching the API.

## Test plan

- [x] Full suite green locally against the production build: **42 passed** across both projects
- [x] `npm run lint` and `tsc --noEmit` clean
- [x] Confirmed `tsc --noEmit` exits 0 on a checkout with no `.next/` present, which is how the lint job runs it
- [x] **Mutation-checked the suite isn't vacuous**: reintroducing the iOS zoom regression (input back to 14px) failed the expected test with `Expected: >= 16 / Received: 14`, and only that test
- [x] Workflow YAML parses; jobs `lint` and `e2e`, triggers `pull_request` + `push` on the three branches

Worth noting: this PR is the first run of the workflow, so the checks appearing on it are themselves the proof it works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LS9KrT9GF2W4zJKH7R2EwU)_